### PR TITLE
Add theme provider wrapper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
+import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
@@ -13,20 +14,22 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/search" element={<Search />} />
-          <Route path="/compare" element={<Compare />} />
-          <Route path="/travel" element={<Travel />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
+    <ThemeProvider>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/search" element={<Search />} />
+            <Route path="/compare" element={<Compare />} />
+            <Route path="/travel" element={<Travel />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,10 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => (
+  <NextThemesProvider attribute="class" defaultTheme="system" enableSystem {...props}>
+    {children}
+  </NextThemesProvider>
+);
+
+export { ThemeProvider };


### PR DESCRIPTION
## Summary
- add a reusable theme provider that configures next-themes with class attributes
- wrap the application shell with the theme provider to ensure Toaster and Sonner consume theme context

## Testing
- npm run build
- npm run lint *(fails: existing lint violations in unrelated files such as components/ui/command.tsx and tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e219bdb99c83309a8b4542e92ed55e